### PR TITLE
new import for yaml

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/flosch/pongo"
-	"github.com/go-yaml/go-yaml-v1"
+	"gopkg.in/yaml.v1"
 	"github.com/russross/blackfriday"
 	"io"
 	"io/ioutil"


### PR DESCRIPTION
can't build with the old yaml import now:

```
(master ✗) wes-macbook:wes-jedie go get -u github.com/mattn/jedie
# github.com/go-yaml/go-yaml-v1
../gocode/src/github.com/go-yaml/go-yaml-v1/error.go:4: "ERROR: the correct import path is gopkg.in/yaml.v1 ... " evaluated but not used
```
