### PR TITLE
fix pretty post path

### DIFF
--- a/jedie.go
+++ b/jedie.go
@@ -219,6 +219,9 @@ func (cfg *config) toPost(from string, pageVars pongo2.Context) string {
 			postUrl = strings.Replace(postUrl, ":day", fmt.Sprintf("%02d", date.Day()), -1)
 			postUrl = strings.Replace(postUrl, ":i_day", fmt.Sprintf("%d", date.Day()), -1)
 			postUrl = strings.Replace(postUrl, ":title", title, -1)
+			if cfg.Permalink[len(cfg.Permalink)-1:len(cfg.Permalink)] == "/" {
+				postUrl += "/index"
+			}
 			return filepath.ToSlash(filepath.Clean(filepath.Join(cfg.Destination, postUrl)))
 		}
 	}


### PR DESCRIPTION
`_config.yml`で`permalink`に`pretty`を指定した際、もしくは`/`で終わるパスを指定した際に、生成されるファイルがこれに沿ったものではなかったので修正しました。
